### PR TITLE
Update sdp-types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,13 +221,13 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "0.2.17"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
- "lazy_static",
  "memchr",
- "regex-automata 0.1.10",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -735,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fd-lock"
@@ -1675,15 +1675,9 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata",
  "regex-syntax",
 ]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-automata"
@@ -1957,9 +1951,8 @@ dependencies = [
 
 [[package]]
 name = "sdp-types"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a627289e3b09f15ef88a28b90d6eca3b7eac332b6ffb34c1af290aa956d4ab9"
+version = "0.1.5"
+source = "git+https://github.com/sdroege/sdp-types?rev=89e1a863aebc7b91a500771c93d5c94797f1b034#89e1a863aebc7b91a500771c93d5c94797f1b034"
 dependencies = [
  "bstr",
  "fallible-iterator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ pin-project = "1.0.7"
 pretty-hex = "0.4.0"
 rand = "0.8.3"
 rtsp-types = "0.1.0"
-sdp-types = "0.1.4"
+sdp-types = { git = "https://github.com/sdroege/sdp-types", rev = "89e1a863aebc7b91a500771c93d5c94797f1b034" }
 smallvec = { version = "1.6.1", features = ["union"] }
 thiserror = "1.0.25"
 time = "0.1.43"
@@ -40,7 +40,12 @@ url = "2.2.1"
 [dev-dependencies]
 criterion = { version = "0.5.0", features = ["async_tokio"] }
 mylog = { git = "https://github.com/scottlamb/mylog" }
-tokio = { version = "1.5.0", features = ["io-util", "macros", "rt-multi-thread", "test-util"] }
+tokio = { version = "1.5.0", features = [
+    "io-util",
+    "macros",
+    "rt-multi-thread",
+    "test-util",
+] }
 
 [profile.bench]
 debug = true


### PR DESCRIPTION
We need to use the latest and unreleased version of sdp-types (later than 0.1.5) to support the SDP does not contain a session name.